### PR TITLE
support for i18n fields with empty nested objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ module.exports = function(schema, options) {
 			} else {
 				localyzeCapsule(obj, thisSubObjPath, locale, defaultLocale, only);
 			}
-		} else if (i18nCapsulePathArr.length > 1) {
+		} else if (thisSubObj && i18nCapsulePathArr.length > 1) {
 			if (thisSubObj instanceof Array) {
 				thisSubObj.map(function (i) {
 					localyzeRecursive(i, i18nCapsulePathArr.slice(1), locale, defaultLocale, only);

--- a/test/helper.js
+++ b/test/helper.js
@@ -49,6 +49,21 @@ module.exports = {
 		});
 	},
 
+	createI18nNestedObjectSchemaWithMultipleFields: function() {
+		return new mongoose.Schema({
+			nested: {
+				name: {
+					type: String,
+					i18n: true
+				}
+			},
+			name: {
+				type: String,
+				i18n: true
+			}
+		});
+	},
+
 	createI18nNestedArraySchema: function() {
 		return new mongoose.Schema({
 			nested: [{

--- a/test/tests/i18n.js
+++ b/test/tests/i18n.js
@@ -262,6 +262,34 @@ module.exports = function() {
 			done();
 		});
 
+		it('should store i18n fields with empty nested objects', function(done) {
+			var Model = mongoose.model('I18nNestedObjectSchema', helper.createI18nNestedObjectSchemaWithMultipleFields().plugin(mongooseI18n, {
+				locales: ['en', 'de']
+			}));
+
+			var model = new Model({
+				name: {
+					en: 'hello',
+					de: 'hallo'
+				}
+			});
+
+			model.name.en.should.equal('hello');
+			model.name.de.should.equal('hallo');
+
+			var json = Model.schema.methods.toJSONLocalized(model, 'de');
+			json.name.en.should.equal('hello');
+			json.name.de.should.equal('hallo');
+			json.name.localized.should.equal('hallo');
+
+			var obj = Model.schema.methods.toObjectLocalized(model, 'en');
+			obj.name.en.should.equal('hello');
+			obj.name.de.should.equal('hallo');
+			obj.name.localized.should.equal('hello');
+
+			done();
+		});
+
 		it('should store i18n fields in nested array', function(done) {
 			var Model = mongoose.model('I18nNestedArraySchema', helper.createI18nNestedArraySchema().plugin(mongooseI18n, {
 				locales: ['en', 'de']


### PR DESCRIPTION
If a field at a deep object path with `i18n:true` is empty or not set an error occurs. 
This PR fixes that issue.